### PR TITLE
URL encode the returned filename

### DIFF
--- a/includes/core.php
+++ b/includes/core.php
@@ -22,7 +22,7 @@ function save_file ($file, $name, $arg){
     //Move the file to the above location with said filename
     move_uploaded_file($file,$path.$file_name);
     //Return url+filename to the user
-    echo 'http://a.uguu.se/'.$file_name;
+    echo 'http://a.uguu.se/'.urlencode($file_name);
 }
 function gen_name($arg, $in){
     $chars = 'abcdefghijklmnopqrstuvwxyz';

--- a/includes/core.php
+++ b/includes/core.php
@@ -1,4 +1,4 @@
-?php
+<?php
 function save_file ($file, $name, $arg){
     //Where to save
     $path='/home/neku/www/files/';


### PR DESCRIPTION
There's a minor pain whenever you upload a file that has, say a space or a #, in the filename right now, as it's not directly usable in IM and the likes.

Pretty easy fix though.

Also, I took the liberty of fixing your opening <?php tag. Neku, you're too silly.