### PR TITLE
Remove trailing ?>

### DIFF
--- a/includes/core.php
+++ b/includes/core.php
@@ -69,4 +69,3 @@ function gen_name($arg, $in){
             break;
     }
 }
-?>


### PR DESCRIPTION
I'm getting an annoying newline in the response, this probably won't fix it, but it's worth a shot since it's a bad idea to have ?> at the end anyway