### PR TITLE
Add a whitelist mode

### DIFF
--- a/includes/config.template.php
+++ b/includes/config.template.php
@@ -15,7 +15,11 @@ define("CONFIG_MAX_RETENTION_TIME", "60");
 define("CONFIG_MAX_RETENTION_TEXT", "1 hour");
 //Length of the random chain appended to the filename
 define("CONFIG_RANDOM_LENGTH", "12");
-//This is the list of blocked extensions, you can remove extensions or add to this list as you like
-define ("CONFIG_BLOCKED_EXTENSIONS", serialize(array("exe", "scr", "rar", "zip", "com", "vbs", "bat", "cmd", "html", "htm", "msi", "php", "php5")));
+//Operate on a BLACKLIST or a WHITELIST when blocking file extensions
+define("CONFIG_EXTENSION_BLOCKING_MODE", "BLACKLIST");
+//This is the list of blocked extensions in BLACKLIST mode (default mode), you can remove extensions or add to this list as you like
+define("CONFIG_BLOCKED_EXTENSIONS", serialize(array("exe", "scr", "rar", "zip", "com", "vbs", "bat", "cmd", "html", "htm", "msi", "php", "php5")));
+//This is the list of allowed extensions in WHITELIST mode, you can remove extensions or add to this list as you like
+define("CONFIG_ALLOWED_EXTENSIONS", serialize(array("txt", "pdf")));
 //https://wiki.gentoo.org/wiki/Handbook to set this string correctly, or just ignore it
 define("VERYLO_NG_STRING_THATDOESNTREALLYD_O_ANYTHING", "ok");

--- a/includes/core.php
+++ b/includes/core.php
@@ -65,7 +65,7 @@ function gen_name($arg, $in){
 
 //Verify that the extension is allowed
 function verify_extension($ext, $type){
-    if(CONFIG_EXTENSION_BLOCKING_MODE == "WHITELIST") {
+    if(CONFIG_EXTENSION_BLOCKING_MODE === "WHITELIST") {
         $allowed = in_array($ext, unserialize(CONFIG_ALLOWED_EXTENSIONS));
     }else{
         $allowed = !in_array($ext, unserialize(CONFIG_BLOCKED_EXTENSIONS));

--- a/includes/core.php
+++ b/includes/core.php
@@ -9,14 +9,7 @@ function save_file ($file, $name, $arg, $type){
         case 'random':
             $ext = pathinfo($file.$name, PATHINFO_EXTENSION);
             $ext = strtolower($ext);
-            if(in_array($ext, unserialize(CONFIG_BLOCKED_EXTENSIONS))){
-              if($type==='normal'){
-                include_once(CONFIG_ROOT_PATH.'error_meow.php');
-                exit(0);
-              }else{
-                exit('File type not allowed.');
-              }
-            }
+            verify_extension($ext, $type);
             $file_name = gen_name('random', $ext);
             while(file_exists(CONFIG_FILES_PATH.$file_name)){
               $file_name = gen_name('random', $ext);
@@ -28,14 +21,7 @@ function save_file ($file, $name, $arg, $type){
                 $file_name = gen_name('custom_original', $name);
                 $ext = pathinfo($file_name, PATHINFO_EXTENSION);
                 $ext = strtolower($ext);
-                if(in_array($ext, unserialize(CONFIG_BLOCKED_EXTENSIONS))){
-                 if($type==='normal'){
-                   include_once(CONFIG_ROOT_PATH.'error_meow.php');
-                   exit(0);
-                 }else{
-                   exit('File type not allowed.');
-                 }
-                }
+                verify_extension($ext, $type);
             while(file_exists(CONFIG_FILES_PATH.$file_name)){
                 $file_name = gen_name('custom_original', $name);
             }
@@ -74,5 +60,23 @@ function gen_name($arg, $in){
         case 'custom_original':
             return $name.'_'.$in;
             break;
+    }
+}
+
+//Verify that the extension is allowed
+function verify_extension($ext, $type){
+    if(CONFIG_EXTENSION_BLOCKING_MODE == "WHITELIST") {
+        $allowed = in_array($ext, unserialize(CONFIG_ALLOWED_EXTENSIONS));
+    }else{
+        $allowed = !in_array($ext, unserialize(CONFIG_BLOCKED_EXTENSIONS));
+    }
+
+    if(!$allowed){
+        if($type==='normal'){
+            include_once(CONFIG_ROOT_PATH.'error_meow.php');
+            exit(0);
+        }else{
+            exit('File type not allowed.');
+        }
     }
 }


### PR DESCRIPTION
This PR adds a config option to use a whitelist for file extensions instead of a blacklist.

It will use blacklist mode if the new `CONFIG_EXTENSION_BLOCKING_MODE` config is not found, so it doesn't break compatibility with existing deployments.