### PR TITLE
Ensure no trailing dot in random filenames

### DIFF
--- a/includes/core.php
+++ b/includes/core.php
@@ -69,7 +69,10 @@ function gen_name($arg, $in){
         }
     switch($arg){
         case 'random':
-            return $name.'.'.$in;
+            if($in){
+                return $name.'.'.$in;
+            }
+            return $name;
             break;
         case 'custom_original':
             return $name.'_'.$in;


### PR DESCRIPTION
Currently, if an uploaded file does not have a proper extension, randomly generated URLs look like this:
`https://installation/files/A6CdE.`

Notice the dot at the end of the filename. We don't want this, since the ending dot is often separated from the URL when the linked is pasted to chat rooms, etc.

This small fix causes `gen_name()` to simply return the name only, if the extension does not exist.