### PR TITLE
Update config.json to align with docs

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -28,7 +28,7 @@
   "kofiUrl": "",
   "malwareBanner": false,
   "DB_MODE": "sqlite",
-  "DB_PATH": "/var/www/db/uguuDB.sq3",
+  "DB_PATH": "/var/www/db/uguu.sq3",
   "DB_USER": "NULL",
   "DB_PASS": "NULL",
   "LOG_IP": false,


### PR DESCRIPTION
Noticed that the db file name in the docs and the template config.json were different. Required a bit of debugging to root cause. Changing it to the file name listed in the installation guide in docs.uguu.se.