### PR TITLE
Added very minimalist support for an S3 backend...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ uguu.sq3
 composer.phar
 composer.lock
 docker/uguuForDocker.tar.gz
+.terraform*
+terraform.tfstate

--- a/src/Classes/Upload.php
+++ b/src/Classes/Upload.php
@@ -18,7 +18,7 @@
      * along with this program.  If not, see <https://www.gnu.org/licenses/>.
      */
     namespace Pomf\Uguu\Classes;
-    require '../vendor/autoload.php';
+    require_once '../vendor/autoload.php';
     use Aws\S3\S3Client;
     use Aws\Exception\AwsException;
     

--- a/src/composer.json
+++ b/src/composer.json
@@ -18,7 +18,8 @@
   "minimum-stability": "stable",
   "require": {
     "ext-fileinfo": "*",
-    "ext-pdo": "*"
+    "ext-pdo": "*",
+    "aws/aws-sdk-php": "^3.269"
   },
   "config": {
     "optimize-autoloader": true,

--- a/src/config.json
+++ b/src/config.json
@@ -38,6 +38,10 @@
   "RATE_LIMIT": false,
   "RATE_LIMIT_TIMEOUT": 60,
   "RATE_LIMIT_FILES": 100,
+  "FILES_OBJ": false,
+  "FILES_OBJ_BUCKET": "my_bucket",
+  "FILES_OBJ_REGION": "my_aws_region",
+  "FILES_OBJ_PROFILE": "default",
   "FILES_ROOT": "/var/www/files/",
   "FILES_RETRIES": 15,
   "NAME_LENGTH": 8,
@@ -75,3 +79,4 @@
     "image/svg+xml"
   ]
 }
+

--- a/src/static/terraform/main.tf
+++ b/src/static/terraform/main.tf
@@ -28,6 +28,10 @@ resource "aws_s3_bucket_lifecycle_configuration" "uguu_lc_policy" {
 
 resource "aws_s3_bucket_public_access_block" "uguu_public_block_policy" {
   bucket = aws_s3_bucket.uguu_bucket.id
+  block_public_acls = true
+  ignore_public_acls = true
+  block_public_policy = false
+  restrict_public_buckets = false
 }
 
 resource "aws_s3_bucket_policy" "uguu_bucket_policy" {

--- a/src/static/terraform/main.tf
+++ b/src/static/terraform/main.tf
@@ -1,0 +1,53 @@
+provider "aws" {}
+
+variable "uguu_bucket_name" {
+  type        = string
+  description = "Bucket Name to be used for Uguu Storage Backend"
+}
+
+variable "retention_days" {
+  type        = number
+  description = "Number of hours for lifecycle policy to retain files before deleting them"
+  default     = 2
+}
+
+resource "aws_s3_bucket" "uguu_bucket" {
+  bucket = var.uguu_bucket_name
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "uguu_lc_policy" {
+  bucket = aws_s3_bucket.uguu_bucket.id
+  rule {
+    id     = "delete-after-x-days"
+    status = "Enabled"
+    expiration {
+      days = var.retention_days
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "uguu_public_block_policy" {
+  bucket = aws_s3_bucket.uguu_bucket.id
+}
+
+resource "aws_s3_bucket_policy" "uguu_bucket_policy" {
+  bucket = aws_s3_bucket.uguu_bucket.id
+  policy = data.aws_iam_policy_document.allow_public_access.json
+}
+
+data "aws_iam_policy_document" "allow_public_access" {
+  statement {
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "s3:GetObject"
+    ]
+
+    resources = [
+      "${aws_s3_bucket.uguu_bucket.arn}/*"
+    ]
+  }
+}

--- a/src/static/terraform/terraform.tfvars
+++ b/src/static/terraform/terraform.tfvars
@@ -1,0 +1,2 @@
+uguu_bucket_name = "YOUR_BUCKET_NAME"
+retention_days   = 2


### PR DESCRIPTION
making use of a a publicly readable S3 bucket.

Terraform project included at src/static/terraform to describe the S3 bucket and attached policies necessary to make it publicly readable.  Also configures an object lifecycle policy to handle our auto-deletion and obviate the need for a cron job when using S3 storage.

Relies on a local AWS CLI Profile existing on the server with read/write permissions to the configured bucket.

Adds 4 new related config.json variables, for AWS Profile, Region and Bucket and a boolean to enable S3 storage, otherwise defaulting to the existing local files backend.

Adds no new error handling, but configured correctly, it works great on my end and simply returns the uploaded file's S3 URL, fully offloading downloads to AWS S3.

I too am a sysops guy, but with pretty limited experience writing PHP. If you reject my PR (and feel free to, it won't hurt my feelings) hopefully this can be of benefit to someone.  I just built it quick and dirty for myself because the instance I'm running this on only has a single volume and I didn't want to risk an attack that would let someone fill up my local disk and affect other services.  Now the worst they can can do is max out out my AWS bill, but at least S3 is still way cheaper than block storage.
